### PR TITLE
Resolve config attribute errors for adaptdiffuser (from `args.horizon` to `args.task.horizon`)

### DIFF
--- a/pipelines/adaptdiffuser_d4rl_antmaze.py
+++ b/pipelines/adaptdiffuser_d4rl_antmaze.py
@@ -131,7 +131,7 @@ def pipeline(args):
             prior = torch.zeros((sample_bs, args.task.horizon, obs_dim + act_dim), device=args.device)
             prior[:, 0, :obs_dim] = batch["obs"]["state"][:, 0].to(args.device)
             traj, log = agent.sample(
-                prior, n_samples=sample_bs, sample_steps=args.sample_steps, solver=args.solver,
+                prior, n_samples=sample_bs, sample_steps=args.sampling_steps, solver=args.solver,
                 use_ema=args.use_ema, w_cg=args.task.w_cg, temperature=args.temperature)
             logp = log["log_p"]
 

--- a/pipelines/adaptdiffuser_d4rl_antmaze.py
+++ b/pipelines/adaptdiffuser_d4rl_antmaze.py
@@ -119,7 +119,7 @@ def pipeline(args):
 
         agent.eval()
 
-        traj_buffer = torch.empty((50000, args.horizon, obs_dim + act_dim), device=args.device)
+        traj_buffer = torch.empty((50000, args.task.horizon, obs_dim + act_dim), device=args.device)
         sample_bs, preserve_bs, ptr = 20000, 1000, 0
 
         gen_dl = DataLoader(
@@ -128,7 +128,7 @@ def pipeline(args):
         for batch in loop_dataloader(gen_dl):
 
             # generate high-quality synthetic trajectories
-            prior = torch.zeros((sample_bs, args.horizon, obs_dim + act_dim), device=args.device)
+            prior = torch.zeros((sample_bs, args.task.horizon, obs_dim + act_dim), device=args.device)
             prior[:, 0, :obs_dim] = batch["obs"]["state"][:, 0].to(args.device)
             traj, log = agent.sample(
                 prior, n_samples=sample_bs, sample_steps=args.sample_steps, solver=args.solver,

--- a/pipelines/adaptdiffuser_d4rl_kitchen.py
+++ b/pipelines/adaptdiffuser_d4rl_kitchen.py
@@ -118,7 +118,7 @@ def pipeline(args):
 
         agent.eval()
 
-        traj_buffer = torch.empty((50000, args.horizon, obs_dim + act_dim), device=args.device)
+        traj_buffer = torch.empty((50000, args.task.horizon, obs_dim + act_dim), device=args.device)
         sample_bs, preserve_bs, ptr = 20000, 1000, 0
 
         gen_dl = DataLoader(
@@ -127,7 +127,7 @@ def pipeline(args):
         for batch in loop_dataloader(gen_dl):
 
             # generate high-quality synthetic trajectories
-            prior = torch.zeros((sample_bs, args.horizon, obs_dim + act_dim), device=args.device)
+            prior = torch.zeros((sample_bs, args.task.horizon, obs_dim + act_dim), device=args.device)
             prior[:, 0, :obs_dim] = batch["obs"]["state"][:, 0].to(args.device)
             traj, log = agent.sample(
                 prior, n_samples=sample_bs, sample_steps=args.sample_steps, solver=args.solver,

--- a/pipelines/adaptdiffuser_d4rl_kitchen.py
+++ b/pipelines/adaptdiffuser_d4rl_kitchen.py
@@ -130,7 +130,7 @@ def pipeline(args):
             prior = torch.zeros((sample_bs, args.task.horizon, obs_dim + act_dim), device=args.device)
             prior[:, 0, :obs_dim] = batch["obs"]["state"][:, 0].to(args.device)
             traj, log = agent.sample(
-                prior, n_samples=sample_bs, sample_steps=args.sample_steps, solver=args.solver,
+                prior, n_samples=sample_bs, sample_steps=args.sampling_steps, solver=args.solver,
                 use_ema=args.use_ema, w_cg=args.task.w_cg, temperature=args.temperature)
             logp = log["log_p"]
 

--- a/pipelines/adaptdiffuser_d4rl_mujoco.py
+++ b/pipelines/adaptdiffuser_d4rl_mujoco.py
@@ -118,7 +118,7 @@ def pipeline(args):
 
         agent.eval()
 
-        traj_buffer = torch.empty((50000, args.horizon, obs_dim + act_dim), device=args.device)
+        traj_buffer = torch.empty((50000, args.task.horizon, obs_dim + act_dim), device=args.device)
         sample_bs, preserve_bs, ptr = 20000, 1000, 0
 
         gen_dl = DataLoader(
@@ -127,7 +127,7 @@ def pipeline(args):
         for batch in loop_dataloader(gen_dl):
 
             # generate high-quality synthetic trajectories
-            prior = torch.zeros((sample_bs, args.horizon, obs_dim + act_dim), device=args.device)
+            prior = torch.zeros((sample_bs, args.task.horizon, obs_dim + act_dim), device=args.device)
             prior[:, 0, :obs_dim] = batch["obs"]["state"][:, 0].to(args.device)
             traj, log = agent.sample(
                 prior, n_samples=sample_bs, sample_steps=args.sample_steps, solver=args.solver,

--- a/pipelines/adaptdiffuser_d4rl_mujoco.py
+++ b/pipelines/adaptdiffuser_d4rl_mujoco.py
@@ -130,7 +130,7 @@ def pipeline(args):
             prior = torch.zeros((sample_bs, args.task.horizon, obs_dim + act_dim), device=args.device)
             prior[:, 0, :obs_dim] = batch["obs"]["state"][:, 0].to(args.device)
             traj, log = agent.sample(
-                prior, n_samples=sample_bs, sample_steps=args.sample_steps, solver=args.solver,
+                prior, n_samples=sample_bs, sample_steps=args.sampling_steps, solver=args.solver,
                 use_ema=args.use_ema, w_cg=args.task.w_cg, temperature=args.temperature)
             logp = log["log_p"]
 


### PR DESCRIPTION
I have updated the attribute access from `args.horizon` to `args.task.horizon` due to the restructured config in `pipelines/adaptdiffuser_d4rl_*.py`, to align with the config yaml correctly.