### PR TITLE
Dimension error with half_jannerunet.py, when horizon is not the power of 2.

### DIFF
--- a/cleandiffuser/nn_classifier/half_jannerunet.py
+++ b/cleandiffuser/nn_classifier/half_jannerunet.py
@@ -76,7 +76,7 @@ class HalfJannerUNet1d(BaseNNDiffusion):
             ]))
 
             if not is_last:
-                horizon = horizon // 2
+                horizon = (horizon - 1) // 2 + 1
 
         mid_dim = dims[-1]
         mid_dim_2 = mid_dim // 2
@@ -85,12 +85,12 @@ class HalfJannerUNet1d(BaseNNDiffusion):
         self.mid_block1 = nn.ModuleList([
             ResidualBlock(mid_dim, mid_dim_2, model_dim, kernel_size=5, norm_type=norm_type),
             Downsample1d(mid_dim_2)])
-        horizon = horizon // 2
+        horizon = (horizon - 1) // 2 + 1
 
         self.mid_block2 = nn.ModuleList([
             ResidualBlock(mid_dim_2, mid_dim_3, model_dim, kernel_size=5, norm_type=norm_type),
             Downsample1d(mid_dim_3)])
-        horizon = horizon // 2
+        horizon = (horizon - 1) // 2 + 1
 
         fc_dim = mid_dim_3 * max(horizon, 1)
 


### PR DESCRIPTION
This bug is also found in Janner's original Diffuser repo.

When horizon is not the power of 2 (and also > 32), dimension errors may occur. Try horizon=30, 40, 63 eta.

The correct behavior is (horizon + 2 * padding - kernel_size) // 2 + 1 = (horizon -1) // 2 + 1, which matches the downsampling behavior using `nn.Conv1d(dim, dim, 3, 2, 1)`.